### PR TITLE
Update allora chain registration flow

### DIFF
--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -54,8 +54,8 @@ func parseFlags() *alloraCfg {
 	pflag.Float64Var(&cfg.CPUPercentage, "cpu-percentage-limit", 1.0, "amount of CPU time allowed for Blockless Functions in the 0-1 range, 1 being unlimited")
 	pflag.Int64Var(&cfg.MemoryMaxKB, "memory-limit", 0, "memory limit (kB) for Blockless Functions")
 
-	// Cosmos L1 configuration
-	pflag.StringVarP(&cfg.AppChainConfig.CosmosHomeDir, "allora-chain-home-dir", "", "", "The Home folder of the client, use the user home if not set")
+	// Allora L1 configuration
+	pflag.StringVarP(&cfg.AppChainConfig.AlloraHomeDir, "allora-chain-home-dir", "", "", "The Home folder of the client, use the user home if not set")
 	pflag.StringVarP(&cfg.AppChainConfig.AddressKeyName, "allora-chain-key-name", "", "", "The name of a key stored in the Allora Blockchain Wallet")
 	pflag.StringVarP(&cfg.AppChainConfig.AddressRestoreMnemonic, "allora-chain-restore-mnemonic", "", "", "The restore mnemonic for an Allora Blockchain Wallet")
 	pflag.StringVarP(&cfg.AppChainConfig.AddressAccountPassphrase, "allora-chain-account-password", "", "", "The password for an Allora Blockchain Wallet Key")

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -37,7 +37,7 @@ func main() {
 
 func connectToAlloraBlockchain(cfg AppChainConfig, log zerolog.Logger) (*AppChain, error) {
 	appchain, err := NewAppChain(cfg, log)
-	if err != nil {
+	if err != nil || appchain == nil {
 		log.Warn().Err(err).Msg("error connecting to allora blockchain")
 		return nil, err
 	}

--- a/cmd/node/types.go
+++ b/cmd/node/types.go
@@ -26,12 +26,12 @@ type AppChain struct {
 
 type AppChainConfig struct {
 	NodeRPCAddress           string // rpc node to attach to
-	AddressPrefix            string // prefix for the cosmos addresses
+	AddressPrefix            string // prefix for the allora addresses
 	AddressKeyName           string // load a address by key from the keystore
 	AddressRestoreMnemonic   string
 	AddressAccountPassphrase string
-	CosmosHomeDir            string // home directory for the cosmos keystore
-	StringSeperator          string // string seperator used for key identifiers in cosmos
+	AlloraHomeDir            string // home directory for the allora keystore
+	StringSeperator          string // string seperator used for key identifiers in allora
 	LibP2PKey                string // the libp2p key used to sign offchain communications
 	SubmitTx                 bool   // do we need to commit these to the chain, might be a reason not to
 	MultiAddress             string

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,11 @@ toolchain go1.21.5
 
 require (
 	cosmossdk.io/math v1.2.0
-	github.com/allora-network/allora-chain v0.0.0-20240208180735-24a88913f37e
+	github.com/allora-network/allora-chain v0.0.0-20240222130242-ea5a963913cc
 	github.com/cockroachdb/pebble v1.0.0
 	github.com/cosmos/cosmos-sdk v0.50.3
 	github.com/ignite/cli/v28 v28.1.1
 	github.com/labstack/echo/v4 v4.11.4
-	github.com/libp2p/go-libp2p v0.32.2
 	github.com/multiformats/go-multiaddr v0.12.2
 	github.com/spf13/pflag v1.0.5
 )
@@ -146,6 +145,7 @@ require (
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect
 	github.com/libp2p/go-flow-metrics v0.1.0 // indirect
+	github.com/libp2p/go-libp2p v0.32.2 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.4.1 // indirect
 	github.com/libp2p/go-libp2p-consensus v0.0.1 // indirect
 	github.com/libp2p/go-libp2p-gostream v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/allora-network/allora-chain v0.0.0-20240208180735-24a88913f37e h1:NBwqDe7zqW4gbtjsoofZkhvw7rcji1aQWBgvotPA4Do=
-github.com/allora-network/allora-chain v0.0.0-20240208180735-24a88913f37e/go.mod h1:n/uJmsa0D44UH5bDt+9w8tClIw5wj9P78x35sslefIQ=
+github.com/allora-network/allora-chain v0.0.0-20240222130242-ea5a963913cc h1:CkV7PkQOz5hzzBJL9wdDiBgZmsRBoNgPlFs7ucfV2dM=
+github.com/allora-network/allora-chain v0.0.0-20240222130242-ea5a963913cc/go.mod h1:n/uJmsa0D44UH5bDt+9w8tClIw5wj9P78x35sslefIQ=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=


### PR DESCRIPTION
Adding new flow for registering reputers and workers.

If the address is not registered in any topic, it will trigger the `Register` tx and require an initial staking.
If the address is registered in other topic, it will trigger the  `AddNewRegistration` tx and it will reuse the staking power of the address.

Potential improvements: 
The user can make the first registration in 2 or more topics at once, so we can update the topic id flag to be able to receive multiple topics during initialization. 