### PR TITLE
use staking amount, add initial-stake flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ export GOPRIVATE=github.com/allora-network/allora-appchain
   --rest-api=:6000 \
   --allora-chain-key-name=local-head \
   --allora-chain-restore-mnemonic='your mnemonic words...' --allora-node-rpc-address=https://some-allora-rpc-address/ \
+  --allora-chain-initial-stake=1000
 ```
 ## Worker
 
@@ -54,7 +55,8 @@ export GOPRIVATE=github.com/allora-network/allora-appchain
   --topic=1 \
   --allora-chain-key-name=local-worker \
   --allora-chain-restore-mnemonic='your mnemonic words...' --allora-node-rpc-address=https://some-allora-rpc-address/ \
-  --allora-chain-topic-id=1
+  --allora-chain-topic-id=1 \
+  --allora-chain-initial-stake=1000
 ```
 
 ## Notes 
@@ -66,6 +68,8 @@ If you plan to deploy without wanting to connect to the Allora blockchain, just 
 `--topic` defines the topic internally as a Blockless channel, so the heads are able to identify which workers can respond to requests on that topic.
 
 `--allora-chain-topic-id` is the topic in which your worker registers on the appchain. This will be used for evaluating performance and allocating rewards.
+
+`allora-chain-initial-stake` is the stake that you want your node to register as initial stake. The stake is cross-topic, so this is applied only upon registration of a node on the chain. It will not have an effect on subsequent runs when the node is already registered. To modify node stake, please refer to [Allora Network](github.com/allora-network/allora-appchain) client.
 
 ### Keys
 The `--private-key` sets the Blockless peer key for your particular node. Obviously, please use different keys for different nodes.

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -62,6 +62,7 @@ func parseFlags() *alloraCfg {
 	pflag.StringVarP(&cfg.AppChainConfig.NodeRPCAddress, "allora-node-rpc-address", "", "http://localhost:26657", "The address for the client to connect to a node.")
 	pflag.Uint64Var(&cfg.AppChainConfig.TopicId, "allora-chain-topic-id", 0, "The topic id for the topic that the node will subscribe to.")
 	pflag.Uint64Var(&cfg.AppChainConfig.ReconnectSeconds, "allora-chain-reconnect-seconds", 60, "If connection to Allora Appchain breaks, it will attempt to reconnect with this interval. O means no reconnection.")
+	pflag.Uint64Var(&cfg.AppChainConfig.InitialStake, "allora-chain-initial-stake", 1000, "Upon registering on a new topic, amount of stake to use.")
 
 	pflag.CommandLine.SortFlags = false
 

--- a/cmd/node/types.go
+++ b/cmd/node/types.go
@@ -38,6 +38,7 @@ type AppChainConfig struct {
 	TopicId                  uint64
 	NodeRole                 blockless.NodeRole
 	ReconnectSeconds         uint64 // seconds to wait for reconnection
+	InitialStake             uint64 // uallo to initially stake upon registration on a new topi
 }
 
 type WeightsResponse struct {


### PR DESCRIPTION
Now staking has a minimum setup (default 100)
The previous impl was a mock, setting stake to 1. 
This sets it as an `--allora-chain-initial-stake` flag. 
This is used on node registration, ie initially. Then it is reused via rehypothecation.