### PR TITLE
Move definition of mode to a explict flag, not head/worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ export GOPRIVATE=github.com/allora-network/allora-appchain
 ```
 ## Worker
 
+Worker (for inference or forecast requests) node: 
+
 ```
 ./allora-node \
   --role=worker  \
@@ -60,7 +62,30 @@ export GOPRIVATE=github.com/allora-network/allora-appchain
   --allora-chain-key-name=local-worker \
   --allora-chain-restore-mnemonic='your mnemonic words...' --allora-node-rpc-address=https://some-allora-rpc-address/ \
   --allora-chain-topic-id=1 \
-  --allora-chain-initial-stake=1000
+  --allora-chain-initial-stake=1000 \
+  --allora-chain-worker-mode=worker
+```
+
+Reputer (for reputation requests) node: 
+
+```
+./allora-node \
+  --role=worker  \
+  --peer-db=/data/peerdb \
+  --function-db=/data/function-db \
+  --runtime-path=/app/runtime \
+  --runtime-cli=bls-runtime \
+  --workspace=/data/workspace \
+  --private-key=/var/keys/priv.bin \
+  --port=9011 \
+  --rest-api=:6000 \
+  --boot-nodes=/ip4/<head-ip-addr>/tcp/9010/p2p/<advertised-head-peerid-key>
+  --topic=1 \
+  --allora-chain-key-name=local-worker \
+  --allora-chain-restore-mnemonic='your mnemonic words...' --allora-node-rpc-address=https://some-allora-rpc-address/ \
+  --allora-chain-topic-id=1 \
+  --allora-chain-initial-stake=1000 \
+  --allora-chain-worker-mode=reputer
 ```
 
 ## Notes 

--- a/cmd/node/appchain.go
+++ b/cmd/node/appchain.go
@@ -15,7 +15,6 @@ import (
 
 	cosmossdk_io_math "cosmossdk.io/math"
 	types "github.com/allora-network/allora-chain/x/emissions"
-	"github.com/blocklessnetwork/b7s/models/blockless"
 	"github.com/blocklessnetwork/b7s/node/aggregate"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
@@ -74,7 +73,7 @@ func NewAppChain(config AppChainConfig, log zerolog.Logger) (*AppChain, error) {
 			log.Warn().Err(err).Msg("could not retrieve account from keyring")
 		}
 	} else if config.AddressRestoreMnemonic != "" && config.AddressKeyName != "" {
-		// restore from mneumonic
+		// restore from mnemonic
 		account, err = client.AccountRegistry.Import(config.AddressKeyName, config.AddressRestoreMnemonic, config.AddressAccountPassphrase)
 		if err != nil {
 			if err.Error() == "account already exists" {
@@ -124,7 +123,7 @@ func registerWithBlockchain(appchain *AppChain) {
 	ctx := context.Background()
 
 	isReputer := false
-	if appchain.Config.NodeRole == blockless.HeadNode {
+	if appchain.Config.WorkerMode == WorkerModeReputer {
 		isReputer = true
 	}
 	appchain.Logger.Info().Bool("isReputer", isReputer).Msg("Node mode")

--- a/cmd/node/flags.go
+++ b/cmd/node/flags.go
@@ -63,6 +63,7 @@ func parseFlags() *alloraCfg {
 	pflag.StringSliceVar(&cfg.AppChainConfig.TopicIds, "allora-chain-topic-id", nil, "The topic id for the topic that the node will subscribe to.")
 	pflag.Uint64Var(&cfg.AppChainConfig.ReconnectSeconds, "allora-chain-reconnect-seconds", 60, "If connection to Allora Appchain breaks, it will attempt to reconnect with this interval. O means no reconnection.")
 	pflag.Uint64Var(&cfg.AppChainConfig.InitialStake, "allora-chain-initial-stake", 1000, "Upon registering on a new topic, amount of stake to use.")
+	pflag.StringVarP(&cfg.AppChainConfig.WorkerMode, "allora-chain-worker-mode", "worker", "Worker mode of an Allora Network node.")
 
 	pflag.CommandLine.SortFlags = false
 

--- a/cmd/node/types.go
+++ b/cmd/node/types.go
@@ -39,6 +39,7 @@ type AppChainConfig struct {
 	NodeRole                 blockless.NodeRole
 	ReconnectSeconds         uint64 // seconds to wait for reconnection
 	InitialStake             uint64 // uallo to initially stake upon registration on a new topi
+	WorkerMode               string // Allora Network worker mode to use
 }
 
 type WeightsResponse struct {
@@ -67,4 +68,9 @@ type Response struct {
 var (
 	inferenceType = "inferences"
 	weightsType   = "weights"
+)
+
+const (
+	WorkerModeWorker  = "worker"
+	WorkerModeReputer = "reputer"
 )


### PR DESCRIPTION
Previously, "reputer" or "worker" in a blockless node, was defined by being a head or worker b7s node. 

Now it will be set by an explicit `--allora-chain-worker-mode` flag, values "worker" or "reputer". 

Added to README.