### PR TITLE
Use different topics on worker/reputer

### DIFF
--- a/cmd/node/appchain.go
+++ b/cmd/node/appchain.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"math/big"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	cosmossdk_io_math "cosmossdk.io/math"
@@ -122,18 +122,50 @@ func NewAppChain(config AppChainConfig, log zerolog.Logger) (*AppChain, error) {
 	return appchain, nil
 }
 
+// Function that receives an array of topicId as string, and parses them to uint64 extracting
+// the topicId from the string prior to the "/" character.
+func parseReputerTopicIds(appchain *AppChain, topicIds []string) []uint64 {
+	var parsedTopicIds []uint64
+	for _, topicIdStr := range topicIds {
+		// extract the topicId from the string
+		topicId, err := strconv.ParseUint(topicIdStr[:strings.Index(topicIdStr, "/")], 10, 64)
+		if err != nil {
+			appchain.Logger.Warn().Str("topicId", topicIdStr).Msg("Topic not in correct reputer format")
+			continue
+		}
+		parsedTopicIds = append(parsedTopicIds, topicId)
+	}
+	return parsedTopicIds
+}
+
 // / Registration
 func registerWithBlockchain(appchain *AppChain) {
 	ctx := context.Background()
 
 	isReputer := false
+	// Parse topics into b7sTopicIds as numerical ids. Reputers and worker use different schema.
+	var b7sTopicIds []uint64
 	if appchain.Config.WorkerMode == WorkerModeReputer {
 		isReputer = true
+		b7sTopicIds = parseReputerTopicIds(appchain, appchain.Config.TopicIds)
+	} else if appchain.Config.WorkerMode == WorkerModeWorker {
+		// parse appchain.Config.TopicIds to uint64 array
+		for _, topicId := range appchain.Config.TopicIds {
+			topicUint64, err := strconv.ParseUint(topicId, 10, 64)
+			if err != nil {
+				appchain.Logger.Warn().Err(err).Str("topic", topicId).Msg("Could not register for topic, not numerical")
+				continue
+			}
+			b7sTopicIds = append(b7sTopicIds, topicUint64)
+		}
+	} else {
+		appchain.Logger.Fatal().Str("WorkerMode", appchain.Config.WorkerMode).Msg("Invalid Worker Mode")
+
 	}
 	appchain.Logger.Info().Bool("isReputer", isReputer).Msg("Node mode")
 	appchain.Logger.Info().Str("Address", appchain.ReputerAddress).Msg("Node address")
 
-	// Check if address is already registered in a topic
+	// Check if address is already registered in a topic, getting all topics already reg'd
 	res, err := appchain.QueryClient.GetRegisteredTopicIds(ctx, &types.QueryRegisteredTopicIdsRequest{
 		Address:   appchain.ReputerAddress,
 		IsReputer: isReputer,
@@ -150,26 +182,20 @@ func registerWithBlockchain(appchain *AppChain) {
 		var topicsToDeRegister []uint64
 		// Calculate topics to deregister
 		for _, topicUint64 := range res.TopicIds {
-			topicIdStr := strconv.FormatUint(uint64(topicUint64), 10)
-			if !slices.Contains(appchain.Config.TopicIds, topicIdStr) {
-				appchain.Logger.Info().Str("topic", topicIdStr).Msg("marking deregistration for topic")
+			if !slices.Contains(b7sTopicIds, topicUint64) {
+				appchain.Logger.Info().Uint64("topic", topicUint64).Msg("marking deregistration for topic")
 				topicsToDeRegister = append(topicsToDeRegister, topicUint64)
 			} else {
-				appchain.Logger.Info().Str("topic", topicIdStr).Msg("Not deregistering topic")
+				appchain.Logger.Info().Uint64("topic", topicUint64).Msg("Not deregistering topic")
 			}
 		}
 		// Calculate topics to register
-		for _, topicIdStr := range appchain.Config.TopicIds {
-			topicUint64, err := strconv.ParseUint(topicIdStr, 10, 64)
-			if err != nil {
-				appchain.Logger.Info().Err(err).Uint64("topic", topicUint64).Msg("Could not register for topic, not numerical")
-				continue
-			}
+		for _, topicUint64 := range b7sTopicIds {
 			if !slices.Contains(res.TopicIds, topicUint64) {
 				appchain.Logger.Info().Uint64("topic", topicUint64).Msg("marking registration for topic")
 				topicsToRegister = append(topicsToRegister, topicUint64)
 			} else {
-				appchain.Logger.Info().Str("topic", topicIdStr).Msg("Topic is already registered, no registration for topic")
+				appchain.Logger.Info().Uint64("topic", topicUint64).Msg("Topic is already registered, no registration for topic")
 			}
 		}
 		// Registration on new topics
@@ -232,17 +258,18 @@ func registerWithBlockchain(appchain *AppChain) {
 				for _, coin := range balanceRes {
 					if coin.Denom == "uallo" {
 						// Found the balance in "uallo"
-						expo := new(big.Int).Exp(big.NewInt(10), big.NewInt(AlloraExponent), nil)
-						ualloBalance = new(big.Int).Div(coin.Amount.BigInt(), expo).Uint64()
+						appchain.Logger.Info().Str("balance", coin.Amount.BigInt().Text(10)).Msg("Found uallo balance in account, calculating...")
+						ualloBalance = coin.Amount.Uint64()
 						break
+					} else if coin.Denom == "allo" {
+						appchain.Logger.Info().Msg("Found allo balance in account, calculating...")
 					}
 				}
 				if ualloBalance >= appchain.Config.InitialStake {
 					var topicsToRegister []uint64
-					for _, topicToRegister := range appchain.Config.TopicIds {
-						topicToRegisterUint64, err := strconv.ParseUint(topicToRegister, 10, 64)
+					for _, topicToRegisterUint64 := range b7sTopicIds {
 						if err != nil {
-							appchain.Logger.Info().Err(err).Str("topic", topicToRegister).Msg("Could not register for topic, not numerical, skipping")
+							appchain.Logger.Info().Err(err).Uint64("topicId", topicToRegisterUint64).Msg("Could not register for topic, not numerical, skipping")
 						} else {
 							topicsToRegister = append(topicsToRegister, topicToRegisterUint64)
 						}
@@ -265,7 +292,7 @@ func registerWithBlockchain(appchain *AppChain) {
 					}
 					appchain.Logger.Info().Str("balance", balanceRes.String()).Msg("Registered Node")
 				} else {
-					appchain.Logger.Fatal().Msg("account balance is lower than the initialStake requested")
+					appchain.Logger.Fatal().Int("balance", int(ualloBalance)).Int("InitialStake", int(appchain.Config.InitialStake)).Msg("account balance is lower than the initialStake requested")
 				}
 			} else {
 				appchain.Logger.Info().Str("account", appchain.ReputerAddress).Msg("account is not funded in uallo")

--- a/go.mod
+++ b/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/viper v1.18.2 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
+	github.com/stretchr/testify v1.8.4
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,10 +57,10 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/allora-network/b7s v0.0.1 h1:hGwSszaDqVM4TxIPlTnAwGOQzTdFaf9KyuZIAdeMNik=
-github.com/allora-network/b7s v0.0.1/go.mod h1:AxpenlKJlosA0boPriW5YpydySBwIiRfRfdzsJQmaHA=
-github.com/allora-network/allora-chain v0.0.9 h1:lG31TA9iKrkG3cluxz7bKbsFifFDn6D/M5HhIhiFu9w=
-github.com/allora-network/allora-chain v0.0.9/go.mod h1:asck3eNvUDMmOp8bNNewzK56+wTapLqkHYuG0NqyKwM=
+github.com/allora-network/allora-chain v0.0.9-0.20240329140536-3ce03c25024f h1:S7GHnKDvVGb/yfxhf+Je8d/pEWzCPUWagu7/pWH/cN4=
+github.com/allora-network/allora-chain v0.0.9-0.20240329140536-3ce03c25024f/go.mod h1:asck3eNvUDMmOp8bNNewzK56+wTapLqkHYuG0NqyKwM=
+github.com/allora-network/b7s v0.0.2-0.20240403233031-c6837f0eff24 h1:sTsjoUTPOWmNo1eWmvSmIiYUKwFKBUTOGgZdepH1hek=
+github.com/allora-network/b7s v0.0.2-0.20240403233031-c6837f0eff24/go.mod h1:AxpenlKJlosA0boPriW5YpydySBwIiRfRfdzsJQmaHA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=


### PR DESCRIPTION
* Different b7s topics on worker ( `i`)  and reputer ( `i/reputer`) 
* Topics onchain are numerical, they don't change
* Reputers are expected to use the flags: 
`--topic=1/reputer  --allora-chain-topic-id=1` 
* Workers are  expected to use the flags: 
`--topic=1  --allora-chain-topic-id=1` 

* Chain is expected to call reputer function with
`"topic":"1/reputer"`
* Chain is expected to call worker function with
`"topic":"1"`

The translation of `--topic` to onchain numerical topicId happens on this branch.