### PR TITLE
Diego/ora 1218 reputer types

### DIFF
--- a/cmd/node/appchain.go
+++ b/cmd/node/appchain.go
@@ -390,7 +390,8 @@ func (ap *AppChain) SendWorkerModeData(ctx context.Context, topicId uint64, resu
 func (ap *AppChain) SendReputerModeData(ctx context.Context, topicId uint64, results aggregate.Results) {
 	// Aggregate the forecast from reputer leader
 	var valueBundles []*types.ReputerValueBundle
-	var nonce *types.Nonce
+	var nonceCurrent *types.Nonce
+	var nonceEval *types.Nonce
 
 	for _, result := range results {
 		if len(result.Peers) > 0 {
@@ -417,8 +418,11 @@ func (ap *AppChain) SendReputerModeData(ctx context.Context, topicId uint64, res
 				ap.Logger.Warn().Err(err).Str("peer", peer.String()).Msg("error extracting WorkerDataBundle from stdout, ignoring bundle.")
 				continue
 			}
-			if nonce == nil {
-				nonce = &types.Nonce{BlockHeight: value.BlockHeight}
+			if nonceCurrent == nil {
+				nonceCurrent = &types.Nonce{BlockHeight: value.BlockHeight}
+			}
+			if nonceEval == nil {
+				nonceEval = &types.Nonce{BlockHeight: value.BlockHeightEval}
 			}
 
 			// Here reputer leader can choose to validate data further to ensure set is correct and act accordingly
@@ -446,8 +450,8 @@ func (ap *AppChain) SendReputerModeData(ctx context.Context, topicId uint64, res
 	req := &types.MsgInsertBulkReputerPayload{
 		Sender: ap.ReputerAddress,
 		ReputerRequestNonce: &types.ReputerRequestNonce{
-			ReputerNonce: nonce,
-			WorkerNonce:  nonce,
+			ReputerNonce: nonceCurrent,
+			WorkerNonce:  nonceEval,
 		},
 		TopicId:             topicId,
 		ReputerValueBundles: valueBundles,

--- a/cmd/node/execute.go
+++ b/cmd/node/execute.go
@@ -46,7 +46,7 @@ func sendResultsToChain(log zerolog.Logger, appChainClient *AppChain, res node.C
 		return
 	}
 	stdout := aggregate.Aggregate(res.Data)[0].Result.Stdout
-	log.Info().Str("stdout", stdout).Msg("WASM function stdout result")
+	log.Info().Str("stdout", stdout).Msg("Aggregated stdout result")
 
 	log.Debug().Str("Topic", res.Topic).Str("worker mode", appChainClient.Config.WorkerMode).Msg("Found topic ID")
 

--- a/cmd/node/types.go
+++ b/cmd/node/types.go
@@ -74,8 +74,13 @@ type ValueBundle struct {
 // Wrapper around the ReputerValueBundle to include the block height and topic id for the leader
 type ReputerDataResponse struct {
 	*types.ReputerValueBundle
-	BlockHeight int64 `json:"blockHeight,omitempty"`
-	TopicId     int64 `json:"topicId,omitempty"`
+	BlockHeight     int64 `json:"blockHeight,omitempty"`
+	BlockHeightEval int64 `json:"blockHeightEval,omitempty"`
+	TopicId         int64 `json:"topicId,omitempty"`
+}
+
+type ReputerWASMResponse struct {
+	Value string `json:"value,omitempty"`
 }
 
 const (


### PR DESCRIPTION
* Redefine internal Reputer types, adjustment related
* Adjust nonces, etc 

This PR sends a valid `MsgInsertBulkReputerPayload` parsed from consensus 