### PR TITLE
Update chain + Reputer Worker nonce removal

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -33,8 +33,8 @@ import (
 	"github.com/allora-network/b7s/node"
 	"github.com/allora-network/b7s/peerstore"
 	"github.com/allora-network/b7s/store"
-    "github.com/prometheus/client_golang/prometheus"
-    "github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -44,44 +44,44 @@ const (
 )
 
 var (
-    opsProcessed = prometheus.NewCounter(prometheus.CounterOpts{
-        Name: "allora_node_total_operations",
-        Help: "The total number of processed operations",
-    })
+	opsProcessed = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "allora_node_total_operations",
+		Help: "The total number of processed operations",
+	})
 
 	headRequests = prometheus.NewCounter(prometheus.CounterOpts{
-        Name: "allora_head_node_total_requests",
-        Help: "The total number of request made by head node",
-    })
+		Name: "allora_head_node_total_requests",
+		Help: "The total number of request made by head node",
+	})
 
 	workerResponse = prometheus.NewCounter(prometheus.CounterOpts{
-        Name: "allora_worker_node_total_response",
-        Help: "The total number of responds from worker node",
-    })
+		Name: "allora_worker_node_total_response",
+		Help: "The total number of responds from worker node",
+	})
 
 	reputerResponse = prometheus.NewCounter(prometheus.CounterOpts{
-        Name: "allora_reputer_node_total_response",
-        Help: "The total number of responds from reputer node",
-    })
+		Name: "allora_reputer_node_total_response",
+		Help: "The total number of responds from reputer node",
+	})
 
 	workerChainCommit = prometheus.NewCounter(prometheus.CounterOpts{
-        Name: "allora_worker_node_chain_commit",
-        Help: "The total number of worker commits to the chain",
-    })
+		Name: "allora_worker_node_chain_commit",
+		Help: "The total number of worker commits to the chain",
+	})
 
 	reputerChainCommit = prometheus.NewCounter(prometheus.CounterOpts{
-        Name: "allora_reputer_node_chain_commit",
-        Help: "The total number of reputer commits to the chain",
-    })
+		Name: "allora_reputer_node_chain_commit",
+		Help: "The total number of reputer commits to the chain",
+	})
 )
 
 func init() {
-    prometheus.MustRegister(opsProcessed)
-    prometheus.MustRegister(headRequests)
-    prometheus.MustRegister(workerResponse)
-    prometheus.MustRegister(reputerResponse)
-    prometheus.MustRegister(workerChainCommit)
-    prometheus.MustRegister(reputerChainCommit)
+	prometheus.MustRegister(opsProcessed)
+	prometheus.MustRegister(headRequests)
+	prometheus.MustRegister(workerResponse)
+	prometheus.MustRegister(reputerResponse)
+	prometheus.MustRegister(workerChainCommit)
+	prometheus.MustRegister(reputerChainCommit)
 }
 
 func main() {
@@ -292,9 +292,6 @@ func (e *AlloraExecutor) ExecuteFunction(requestID string, req execute.Request) 
 				ReputerNonce: &types.Nonce{
 					BlockHeight: alloraBlockHeightCurrent,
 				},
-				WorkerNonce: &types.Nonce{
-					BlockHeight: alloraBlockHeightEval,
-				},
 			}
 
 			// Now get the string of the value, unescape it and unmarshall into ValueBundle
@@ -484,7 +481,7 @@ func (e *AlloraExecutor) ExecuteFunction(requestID string, req execute.Request) 
 	}
 
 	// increament the number of operations processed by worker or reputer
-    opsProcessed.Inc()
+	opsProcessed.Inc()
 	return result, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	cosmossdk.io/math v1.3.0
-	github.com/allora-network/allora-chain v0.2.13-0.20240711095825-787633192f37
+	github.com/allora-network/allora-chain v0.2.13-0.20240712153715-51a1470939ab
 	github.com/allora-network/b7s v0.0.2-0.20240626021501-5a913378a8d8
 	github.com/cockroachdb/pebble v1.1.0
 	github.com/cosmos/cosmos-sdk v0.50.5

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	cosmossdk.io/math v1.3.0
-	github.com/allora-network/allora-chain v0.2.11
+	github.com/allora-network/allora-chain v0.2.13-0.20240711095825-787633192f37
 	github.com/allora-network/b7s v0.0.2-0.20240626021501-5a913378a8d8
 	github.com/cockroachdb/pebble v1.1.0
 	github.com/cosmos/cosmos-sdk v0.50.5

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/allora-network/allora-chain v0.2.13-0.20240711095825-787633192f37 h1:dc7/UcloiDQGJp2hmfeED1GvFZmXJGTNQNylDhHn+Ok=
 github.com/allora-network/allora-chain v0.2.13-0.20240711095825-787633192f37/go.mod h1:nYJd641Y0iieiL+t+P5VOWnYdiAq2kiazdbL1Bi4jrw=
+github.com/allora-network/allora-chain v0.2.13-0.20240712153715-51a1470939ab h1:IFVoMze1vnSQ84mFP8Nw14PYWfGq6dGFFV38xb/J2wY=
+github.com/allora-network/allora-chain v0.2.13-0.20240712153715-51a1470939ab/go.mod h1:nYJd641Y0iieiL+t+P5VOWnYdiAq2kiazdbL1Bi4jrw=
 github.com/allora-network/b7s v0.0.2-0.20240626021501-5a913378a8d8 h1:w0MOdikeH7bmSoqJCgc9j9bRp7+sIRK7Rvf0P00S12g=
 github.com/allora-network/b7s v0.0.2-0.20240626021501-5a913378a8d8/go.mod h1:rJJrdC5Y83LEDFxo/iJp3JJpi8I6TJncOTigMWk8ieE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/allora-network/allora-chain v0.2.11 h1:dNKYc9tZA1GwEcLii8U+bmUX/crVxuB2pSq0UQEn07w=
-github.com/allora-network/allora-chain v0.2.11/go.mod h1:nYJd641Y0iieiL+t+P5VOWnYdiAq2kiazdbL1Bi4jrw=
+github.com/allora-network/allora-chain v0.2.13-0.20240711095825-787633192f37 h1:dc7/UcloiDQGJp2hmfeED1GvFZmXJGTNQNylDhHn+Ok=
+github.com/allora-network/allora-chain v0.2.13-0.20240711095825-787633192f37/go.mod h1:nYJd641Y0iieiL+t+P5VOWnYdiAq2kiazdbL1Bi4jrw=
 github.com/allora-network/b7s v0.0.2-0.20240626021501-5a913378a8d8 h1:w0MOdikeH7bmSoqJCgc9j9bRp7+sIRK7Rvf0P00S12g=
 github.com/allora-network/b7s v0.0.2-0.20240626021501-5a913378a8d8/go.mod h1:rJJrdC5Y83LEDFxo/iJp3JJpi8I6TJncOTigMWk8ieE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: Integration of ORA-1785

## What is the purpose of the change

Update to changes on `allora-chain` (ORA-1785) which remove `ReputerRequestNonces.WorkerNonce`, leaving ReputerNonce as the only nonce.
Proto modification needs updating of dependency, and the code that is related.

## Testing and Verifying

- Manually verified the change by deploying a whole setup locally (with chain, head, 1 reputer, 1 worker). 
Basic: Reputation and inference coming in normally.
Inactivation: After inactivation and reactivation of a topic, it also works as expected.


## Documentation and Release Note

  - [ ] Does this pull request introduce a new feature or user-facing behavior changes?


Where is the change documented?
  - [ X ] N/A - Allora documentation as part of chain documentation from ORA-1785 in allora-chain.

