### PR TITLE
Fix missing highestVotingPower update in argmaxBlockByStake

### DIFF
--- a/cmd/node/appchain.go
+++ b/cmd/node/appchain.go
@@ -471,6 +471,7 @@ func (ap *AppChain) argmaxBlockByStake(
 
 		// Decide if voting power exceeds that of current front-runner
 		if firstIter || blockVotingPower.GT(highestVotingPower) {
+			highestVotingPower = blockVotingPower
 			blockOfMaxPower = block
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

This change fixes a bug where the argmaxBlockByStake was incorrectly written, resulting in the function returning the wrong blocks for that function.

## Testing and Verifying

Frankly, I don't know how to adequately test this function, probably it should have its own unit tests.

## Documentation and Release Note

This is an internal code change with no documentation implications.